### PR TITLE
Update python_version for 3.13

### DIFF
--- a/nmap.json
+++ b/nmap.json
@@ -20,7 +20,7 @@
     "logo": "logo_nmap.svg",
     "logo_dark": "logo_nmap_dark.svg",
     "rpm_dependencies": "nmap",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "configuration": {
         "ip_address": {
             "data_type": "string",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)