### PR TITLE
PSAAS-29919 scan_network read only

### DIFF
--- a/nmap.json
+++ b/nmap.json
@@ -50,7 +50,7 @@
             "verbose": "<p>If <b>udp_scan</b> is false (it is by default), this action will use the following NMAP command line options: nmap -oX - -sV IP_ADDRESS.</p><p>If <b>udp_scan</b> is true, this action will use the following NMAP command line options: nmap -oX - -sU --privileged IP_ADDRESS.</p><p>Performing a UDP scan requires elevated permissions.  Privileged permissions can be used, if and only if the user first runs this command as root on Phantom:<br><code>sudo setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip /usr/bin/nmap</code></p><p><b>Warning:</b> UDP function is limited to root for very good reason.  This is dangerous. The NMAP Scripting Engine (NSE) allows scripts to sniff the network, change firewall rules and interface configuration, or exploit vulnerabilities including on localhost. It's possible, especially with elevated capabilities, for a clever person to use NMAP and NSE to escalate to full root privileges. If you do not understand these risks, do not do this.</p><p>To undo the setcap command from before, just run:<br><code>sudo setcap cap_net_raw,cap_net_admin,cap_net_bind_service-eip /usr/bin/nmap</code><br><p>action_result.data.*.udp.* data paths will only be present if <b>udp_scan</b> is true.  They replace action_result.data.*.tcp.* data paths.</p>",
             "type": "investigate",
             "identifier": "nmap_scan",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "ip_hostname": {
                     "description": "IP address/hostname (CIDR notation supported)",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fixed `scan network` action incorrectly marked as `read_only`


### PR DESCRIPTION
### Features
<!-- Delete this section if your PR does not add any features -->
List any features you're adding to this app (e.g. new actions, parameters, auth methods, etc.)

-

### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->
Describe any bugs you've fixed in this app, and how they were fixed

- In the SOAR app nmap, the app action scan network is listed as “read-only” when it allows a user to supply a NSE script to be run during the scan. These scripts can perform CRUD actions including executing commands on a target system. More information on nmap NSE can be found here: [Nmap Scripting Engine (NSE) | Nmap Network Scanning](https://nmap.org/book/man-nse.html) 

 Impact:

A SOAR playbook marked as “safe” (read-only) can perform CRUD actions using nmap’s NSE. The scripts are included in the base install of the nmap SOAR app. 

Recommendations for Remediation:

Change the manifest declaration of "scan network" to `read_only: false`. The
  connector's own README already documents that the action can make persistent
  changes and escalate privileges; the manifest should agree.

**Remediation Taken:** scan_network was set to `read_only: false`.

Verified in app editor.