### PR TITLE
fix: handle malformed scan URLs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.40.7
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.7
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/NOTICE
+++ b/NOTICE
@@ -356,4 +356,3 @@ e) to display the Original Work publicly.
 15) Right to Use. You may use the Original Work in all ways not otherwise restricted or conditioned by this License or by law, and Licensor promises not to interfere with or be responsible for such uses by You.
 
 This license is Copyright (C) 2003-2004 Lawrence E. Rosen. All rights reserved. Permission is hereby granted to copy and distribute this license without modification. This license may not be modified without the express written permission of its copyright owner.
-

--- a/nmap_connector.py
+++ b/nmap_connector.py
@@ -72,7 +72,14 @@ class NmapConnector(BaseConnector):
 
         # PAPP-1802
         if ph_utils.is_url(ip_hostname):
-            ip_hostname = ph_utils.get_host_from_url(ip_hostname)
+            try:
+                ip_hostname = ph_utils.get_host_from_url(ip_hostname)
+            except ValueError as error:
+                return action_result.set_status(
+                    phantom.APP_ERROR,
+                    "Unable to extract a hostname from the provided URL",
+                    error,
+                )
 
         portlist = param.get(NMAP_JSON_PORTLIST)
         if portlist is not None and not self._is_valid_portlist(portlist):

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Fixed scan network to return an action error instead of crashing on malformed URL targets.


### PR DESCRIPTION
## Summary
- handle malformed URL targets without an uncaught exception
- return a connector action error when hostname extraction fails
- refresh connector validation hooks and release notes

## Tracking
- PSAAS-32833
- PAPP-38311
- ESPM-5228

## Validation
- full pre-commit source/static gate (Python 3.13, public package cache)
- package-app-dependencies after Docker recovery
- Python 3.13 compile

Authored and published by Codex.

- [x] AI-assisted change

## Tracking

- PAPP: PAPP-38311
- PSAAS: PSAAS-32833
- Written by Codex.